### PR TITLE
TLUNIZIN-749 Instructors should not recieve emails through the LTI

### DIFF
--- a/src/main/java/edu/umich/ctools/sectionsUtilityTool/Friend.java
+++ b/src/main/java/edu/umich/ctools/sectionsUtilityTool/Friend.java
@@ -49,6 +49,16 @@ public class Friend
 	protected static final String FRIEND_PROPERTY_FILE_PATH = "sectionsToolFriendPropsPath";
 	protected static final String FRIEND_PROPERTY_FILE_PATH_SECURE = "sectionsToolFriendPropsPathSecure";
 
+	protected static final String FRIEND_URL = "umich.friend.url";
+	protected static final String FRIEND_CONTACT_EMAIL = "umich.friend.contactemail"; 
+	protected static final String FRIEND_REFERRER = "umich.friend.referrer";
+	protected static final String FRIEND_FRIEND_EMAIL = "umich.friend.friendemail";
+	protected static final String FRIEND_REQUESTER_EMAIL = "umich.friend.requesteremail";
+	protected static final String FRIEND_MAIL_HOST = "umich.friend.mailhost";
+	protected static final String FRIEND_SUBJECT_LINE = "umich.friend.subjectline";
+	protected static final String FRIEND_KS_FILENAME = "umich.friend.ksfilename";
+	protected static final String FRIEND_KS_PASSWORD = "umich.friend.kspassword";
+
 	protected static final String MAIL_SMTP_AUTH = "mail.smtp.auth";
 	protected static final String MAIL_SMTP_STARTTLS = "mail.smtp.starttls.enable";
 	protected static final String MAIL_SMTP_HOST = "mail.smtp.host";
@@ -59,7 +69,7 @@ public class Friend
 
 	protected static Properties appExtSecureProperties=null;
 	protected static Properties appExtProperties=null;	
-	
+
 	private XmlRpcClient Xclient;
 
 	public Friend() throws MalformedURLException {
@@ -80,15 +90,15 @@ public class Friend
 	public void setProperties(){
 		if(appExtSecureProperties!=null) {
 			//PropertiesFile information
-			friendUrl = appExtProperties.getProperty("umich.friend.url");
-			contactEmail = appExtProperties.getProperty("umich.friend.contactemail");
-			referrerUrl = appExtProperties.getProperty("umich.friend.referrer");
-			friendEmailFile = appExtProperties.getProperty("umich.friend.friendemail");
-			requesterEmailFile = appExtProperties.getProperty("umich.friend.requesteremail");
-			mailHost = appExtProperties.getProperty("umich.friend.mailhost");
-			subjectLine = appExtProperties.getProperty("umich.friend.subjectline");
-			ksFileName = appExtSecureProperties.getProperty("umich.friend.ksfilename");
-			ksPwd = appExtSecureProperties.getProperty("umich.friend.kspassword");
+			friendUrl = appExtProperties.getProperty(FRIEND_URL);
+			contactEmail = appExtProperties.getProperty(FRIEND_CONTACT_EMAIL);
+			referrerUrl = appExtProperties.getProperty(FRIEND_REFERRER);
+			friendEmailFile = appExtProperties.getProperty(FRIEND_FRIEND_EMAIL);
+			requesterEmailFile = appExtProperties.getProperty(FRIEND_REQUESTER_EMAIL);
+			mailHost = appExtProperties.getProperty(FRIEND_MAIL_HOST);
+			subjectLine = appExtProperties.getProperty(FRIEND_SUBJECT_LINE);
+			ksFileName = appExtSecureProperties.getProperty(FRIEND_KS_FILENAME);
+			ksPwd = appExtSecureProperties.getProperty(FRIEND_KS_PASSWORD);
 
 			M_log.debug("ksFileName: " + ksFileName);
 			M_log.debug("ksPwd: " + ksPwd);
@@ -301,7 +311,7 @@ public class Friend
 
 		Properties properties = System.getProperties();
 		properties.put(MAIL_SMTP_AUTH, "false");
-		properties.put(MAIL_SMTP_STARTTLS, "true"); //Put below to false, if no https is needed
+		properties.put(MAIL_SMTP_STARTTLS, "true"); //Put to false, if no https is needed
 		properties.put(MAIL_SMTP_HOST, host);
 		properties.put(MAIL_DEBUG, "true");
 

--- a/src/main/java/edu/umich/ctools/sectionsUtilityTool/FriendServlet.java
+++ b/src/main/java/edu/umich/ctools/sectionsUtilityTool/FriendServlet.java
@@ -22,12 +22,12 @@ public class FriendServlet extends HttpServlet {
 	private static final String INVITE_EMAIL = "inviteEmail";
 	private static final String INSTRUCTOR_EMAIL = "instructorEmail";
 	private static final String INSTRUCTOR_NAME = "instructorName";
-	private static final String SEND_EMAIL = "sendEmail";
+	private static final String NOTIFY_INSTRUCTOR = "notifyInstructor";
 	private static final String PARAMETER_ID = "id";
 	private static final String PARAMETER_INSTRUCTOR_EMAIL = "inst_email";
 	private static final String PARAMETER_INSTRUCTOR_FIRST_NAME = "inst_first_name";
 	private static final String PARAMETER_INSTRUCTOR_LAST_NAME = "inst_last_name";
-	private static final String PARAMETER_SEND_EMAIL = "send_email";
+	private static final String PARAMETER_NOTIFY_INSTRUCTOR = "notify_instructor";
 
 	private final static String CCM_PROPERTY_FILE_PATH = "ccmPropsPath";
 	private final static String CCM_SECURE_PROPERTY_FILE_PATH = "ccmPropsPathSecure";	
@@ -87,7 +87,7 @@ public class FriendServlet extends HttpServlet {
 			String friendInstructorEmail = request.getParameter(PARAMETER_INSTRUCTOR_EMAIL);
 			String friendInstructorFirstName = request.getParameter(PARAMETER_INSTRUCTOR_FIRST_NAME);
 			String friendInstructorLastName = request.getParameter(PARAMETER_INSTRUCTOR_LAST_NAME);
-			String friendSendEmail = request.getParameter(PARAMETER_SEND_EMAIL);
+			String friendNotifyInstructor = request.getParameter(PARAMETER_NOTIFY_INSTRUCTOR);
 			if(friendInviteEmail == null || 
 					friendInstructorEmail == null ||
 					friendInstructorFirstName == null || 
@@ -105,7 +105,7 @@ public class FriendServlet extends HttpServlet {
 						friendInstructorEmail, 
 						friendInstructorFirstName, 
 						friendInstructorLastName,
-						friendSendEmail);
+						friendNotifyInstructor);
 			}
 			break;
 		default:
@@ -132,7 +132,7 @@ public class FriendServlet extends HttpServlet {
 			String instructorEmail, 
 			String instructorFirstName, 
 			String instructorLastName,
-			String friendSendEmail){
+			String friendNotifyInstructor){
 		JsonObject json;
 		String instructorName = instructorFirstName + " " + instructorLastName;
 		
@@ -141,7 +141,7 @@ public class FriendServlet extends HttpServlet {
 		friendValues.put(INVITE_EMAIL, inviteEmail);
 		friendValues.put(INSTRUCTOR_EMAIL, instructorEmail);
 		friendValues.put(INSTRUCTOR_NAME, instructorName);
-		friendValues.put(SEND_EMAIL, friendSendEmail);
+		friendValues.put(NOTIFY_INSTRUCTOR, friendNotifyInstructor);
 		
 		//Step 1: determine if friend exists
 		CheckAccountExistsResponse friendExists = myFriend.checkAccountExist(inviteEmail);
@@ -196,8 +196,8 @@ public class FriendServlet extends HttpServlet {
 
 			//Step 3: send notification to instructor indicating that a friend account has been created.
 			//If LTI don't send email, otherwise it's okay
-			M_log.debug("sendEmail: " + friendValues.get(SEND_EMAIL));
-			if(friendValues.get(SEND_EMAIL) == null || friendValues.get(SEND_EMAIL).equalsIgnoreCase("true")){
+			M_log.debug("sendEmail: " + friendValues.get(NOTIFY_INSTRUCTOR));
+			if(friendValues.get(NOTIFY_INSTRUCTOR) == null || friendValues.get(NOTIFY_INSTRUCTOR).equalsIgnoreCase("true")){
 				Friend.notifyCurrentUser(friendValues.get(INSTRUCTOR_NAME), friendValues.get(INSTRUCTOR_EMAIL), friendValues.get(INVITE_EMAIL));
 			}
 			break;


### PR DESCRIPTION
Due: 10/8/2015
@gsilver 
@dlhaines 
Modified the code to accept new parameter for already existing API call to add friend. If parameter send_mail = null or true, instructor will be notified via email. Otherwise, no email notification is sent. The acceptance of null is for backwards compatibility. I also did some code clean up in Friend.java.