### PR TITLE
TLUNIZIN-837 skip LTI verification if stub.test == true

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,3 @@
-/*
 Copyright 2015-2016 University of Michigan
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,11 +11,3 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-*/
-package edu.umich.ctools.sectionsUtilityTool;
-
-public enum CreateAccountResponse {
-	INVALID_EMAIL,
-	RUNTIME_PROBLEM,
-	INVITATION_SUCCESSFULLY_SENT
-}

--- a/src/main/java/edu/umich/ctools/sectionsUtilityTool/CheckAccountExistsResponse.java
+++ b/src/main/java/edu/umich/ctools/sectionsUtilityTool/CheckAccountExistsResponse.java
@@ -1,3 +1,33 @@
+/*
+Copyright 2015-2016 University of Michigan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+/*
+Copyright 2015-2016 University of Michigan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package edu.umich.ctools.sectionsUtilityTool;
 
 public enum CheckAccountExistsResponse {

--- a/src/main/java/edu/umich/ctools/sectionsUtilityTool/Friend.java
+++ b/src/main/java/edu/umich/ctools/sectionsUtilityTool/Friend.java
@@ -1,3 +1,18 @@
+/*
+Copyright 2015-2016 University of Michigan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package edu.umich.ctools.sectionsUtilityTool;
 
 import java.util.Iterator;

--- a/src/main/java/edu/umich/ctools/sectionsUtilityTool/FriendServlet.java
+++ b/src/main/java/edu/umich/ctools/sectionsUtilityTool/FriendServlet.java
@@ -1,3 +1,18 @@
+/*
+Copyright 2015-2016 University of Michigan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package edu.umich.ctools.sectionsUtilityTool;
 
 import java.io.IOException;

--- a/src/main/java/edu/umich/ctools/sectionsUtilityTool/SectionUtilityToolFilter.java
+++ b/src/main/java/edu/umich/ctools/sectionsUtilityTool/SectionUtilityToolFilter.java
@@ -1,3 +1,18 @@
+/*
+Copyright 2015-2016 University of Michigan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package edu.umich.ctools.sectionsUtilityTool;
 
 import java.io.IOException;

--- a/src/main/java/edu/umich/ctools/sectionsUtilityTool/SectionsUtilityToolServlet.java
+++ b/src/main/java/edu/umich/ctools/sectionsUtilityTool/SectionsUtilityToolServlet.java
@@ -108,8 +108,8 @@ public class SectionsUtilityToolServlet extends VelocityViewServlet {
 	private boolean isStubTesting = false;
 	private OauthCredentialsFactory oacf;
 
-	protected static Properties appExtSecureProperties=null;
-	protected static Properties appExtProperties=null;	
+	protected static Properties appExtSecurePropertiesFile=null;
+	protected static Properties appExtPropertiesFile=null;	
 
 	private static final HashMap<String,String> apiListRegexWithDebugMsg = new HashMap<String,String>(){
 		private static final long serialVersionUID = -1389517682290891890L;
@@ -140,16 +140,16 @@ public class SectionsUtilityToolServlet extends VelocityViewServlet {
 
 	public void init() throws ServletException {
 		M_log.debug(" Servlet init(): Called");
-		appExtProperties = Utils.loadProperties(CCM_PROPERTY_FILE_PATH);
-		appExtSecureProperties = Utils.loadProperties(CCM_SECURE_PROPERTY_FILE_PATH);
+		appExtPropertiesFile = Utils.loadProperties(CCM_PROPERTY_FILE_PATH);
+		appExtSecurePropertiesFile = Utils.loadProperties(CCM_SECURE_PROPERTY_FILE_PATH);
       
-		if(appExtSecureProperties!=null) {
-			ltiKey = appExtSecureProperties.getProperty(SectionUtilityToolFilter.PROPERTY_LTI_KEY);
-			ltiSecret = appExtSecureProperties.getProperty(SectionUtilityToolFilter.PROPERTY_LTI_SECRET);
-			ltiUrl = appExtProperties.getProperty(SectionUtilityToolFilter.PROPERTY_LTI_URL);
-			canvasToken = appExtSecureProperties.getProperty(SectionUtilityToolFilter.PROPERTY_CANVAS_ADMIN);
-			canvasURL = appExtSecureProperties.getProperty(SectionUtilityToolFilter.PROPERTY_CANVAS_URL);
-			isStubTesting = Boolean.valueOf( appExtProperties.getProperty(SectionUtilityToolFilter.PROPERTY_TEST_STUB) );
+		if(appExtSecurePropertiesFile!=null) {
+			ltiKey = appExtSecurePropertiesFile.getProperty(SectionUtilityToolFilter.PROPERTY_LTI_KEY);
+			ltiSecret = appExtSecurePropertiesFile.getProperty(SectionUtilityToolFilter.PROPERTY_LTI_SECRET);
+			ltiUrl = appExtPropertiesFile.getProperty(SectionUtilityToolFilter.PROPERTY_LTI_URL);
+			canvasToken = appExtSecurePropertiesFile.getProperty(SectionUtilityToolFilter.PROPERTY_CANVAS_ADMIN);
+			canvasURL = appExtSecurePropertiesFile.getProperty(SectionUtilityToolFilter.PROPERTY_CANVAS_URL);
+			isStubTesting = Boolean.valueOf( appExtPropertiesFile.getProperty(SectionUtilityToolFilter.PROPERTY_TEST_STUB) );
 			M_log.debug("ltiKey from props: "	 + ltiKey);
 			M_log.debug("ltiSecret from props: " + ltiSecret);
 			M_log.debug("ltiUrl from props: "	 + ltiUrl);
@@ -159,7 +159,7 @@ public class SectionsUtilityToolServlet extends VelocityViewServlet {
 			M_log.error("Failed to load system properties(sectionsToolProps.properties) for SectionsTool");
 		}
       
-		oacf = new OauthCredentialsFactory(appExtSecureProperties);
+		oacf = new OauthCredentialsFactory(appExtSecurePropertiesFile);
 	}
 
 	public void fillContext(Context context, HttpServletRequest request) {
@@ -382,13 +382,13 @@ public class SectionsUtilityToolServlet extends VelocityViewServlet {
 		if ( canvasToken == null || canvasURL == null ) {
 			response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
 			out = response.getWriter();
-			out.print(appExtProperties.getProperty("property.file.load.error"));
+			out.print(appExtPropertiesFile.getProperty("property.file.load.error"));
 			out.flush();
 			M_log.error("Failed to load system properties(sectionsToolProps.properties) for SectionsTool");
 			return;
 		}
 		if(isAllowedApiRequest(request)) {
-			callType = appExtProperties.getProperty(SectionUtilityToolFilter.PROPERTY_CALL_TYPE);
+			callType = appExtPropertiesFile.getProperty(SectionUtilityToolFilter.PROPERTY_CALL_TYPE);
 			if(callType.equals("canvas")){
 				apiConnectionLogic(request,response);
 			}
@@ -398,7 +398,7 @@ public class SectionsUtilityToolServlet extends VelocityViewServlet {
 		}else {
 			response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
 			out = response.getWriter();
-			out.print(appExtProperties.getProperty("api.not.allowed.error"));
+			out.print(appExtPropertiesFile.getProperty("api.not.allowed.error"));
 			out.flush();
 		}
 	}
@@ -449,12 +449,12 @@ public class SectionsUtilityToolServlet extends VelocityViewServlet {
 			M_log.error("Error in mpathwaysCall(), missing parameter in Instuctors request");
 		}
 		else{
-			if(appExtSecureProperties!=null) {
+			if(appExtSecurePropertiesFile!=null) {
 				HashMap<String, String> wapiValuesMap = new HashMap<String, String>();
-				wapiValuesMap.put("tokenServer", appExtSecureProperties.getProperty(SectionUtilityToolFilter.ESB_TOKEN_SERVER));
-				wapiValuesMap.put("apiPrefix", appExtSecureProperties.getProperty(SectionUtilityToolFilter.ESB_PREFIX));
-				wapiValuesMap.put("key", appExtSecureProperties.getProperty(SectionUtilityToolFilter.ESB_KEY));
-				wapiValuesMap.put("secret", appExtSecureProperties.getProperty(SectionUtilityToolFilter.ESB_SECRET));
+				wapiValuesMap.put("tokenServer", appExtSecurePropertiesFile.getProperty(SectionUtilityToolFilter.ESB_TOKEN_SERVER));
+				wapiValuesMap.put("apiPrefix", appExtSecurePropertiesFile.getProperty(SectionUtilityToolFilter.ESB_PREFIX));
+				wapiValuesMap.put("key", appExtSecurePropertiesFile.getProperty(SectionUtilityToolFilter.ESB_KEY));
+				wapiValuesMap.put("secret", appExtSecurePropertiesFile.getProperty(SectionUtilityToolFilter.ESB_SECRET));
 				WAPI wapi = new WAPI(wapiValuesMap);
 				try {
 					String url = wapi.getApiPrefix() + uniqname + "/Terms/" + mpathwaysTermId + "/Classes";
@@ -622,8 +622,8 @@ public class SectionsUtilityToolServlet extends VelocityViewServlet {
 		Set<String> apiListRegex = apiListRegexWithDebugMsg.keySet();
 		for (String api : apiListRegex) {
 			M_log.debug("URL: " + url);
-			M_log.debug("API: " + appExtProperties.getProperty(api));
-			if(url.matches(appExtProperties.getProperty(api))) {
+			M_log.debug("API: " + appExtPropertiesFile.getProperty(api));
+			if(url.matches(appExtPropertiesFile.getProperty(api))) {
 				M_log.debug(prefixDebugMsg+apiListRegexWithDebugMsg.get(api));
 				isMatch= true;
 				break;

--- a/src/main/java/edu/umich/ctools/sectionsUtilityTool/SectionsUtilityToolServlet.java
+++ b/src/main/java/edu/umich/ctools/sectionsUtilityTool/SectionsUtilityToolServlet.java
@@ -1,3 +1,18 @@
+/*
+Copyright 2015-2016 University of Michigan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package edu.umich.ctools.sectionsUtilityTool;
 
 import java.io.BufferedReader;

--- a/src/main/java/edu/umich/ctools/sectionsUtilityTool/Utils.java
+++ b/src/main/java/edu/umich/ctools/sectionsUtilityTool/Utils.java
@@ -1,3 +1,18 @@
+/*
+Copyright 2015-2016 University of Michigan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package edu.umich.ctools.sectionsUtilityTool;
 
 import java.io.BufferedReader;


### PR DESCRIPTION
Bypass LTI oauth validation if stub.test is true
Some refactoring to:
- change public methods to private as appropriate
- don't repeatedly set global variables (e.g. ltiKey)
- change variable names as appropriate (e.g. appExtSecurePropertiesFile -> appExtSecureProperties)