### PR TITLE
#285 upgrading to guava and fixing the warning with artifact relocation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>19.0</version>
+            <version>24.1.1-jre</version>
         </dependency>
 
         <dependency>
@@ -68,7 +68,7 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.apache.commons</groupId>
+			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
 			<version>1.3.2</version>
 		</dependency>


### PR DESCRIPTION
Fixes #285 

I have put the experimental build for this PR on CCMDEV and [Build](https://containers.it.umich.edu/console/project/ccmdev/browse/builds/ccmapp/ccmapp-67?tab=logs) logs says the new version is downloaded

>Downloading from central: https://repo.maven.apache.org/maven2/com/google/guava/guava/24.1.1-jre/guava-24.1.1-jre.pom 
